### PR TITLE
カスタム速度の記録をweb-vitalsだけにする

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -143,8 +143,10 @@ const BlanktarApp = ({ Component, pageProps }: AppProps) => {
 };
 
 
-export function reportWebVitals({ name, value }: {name: string; value: number}) {
-    reportSpeed(name, name === 'CLS' ? value * 1000 : value);
+export function reportWebVitals({ name, value, label }: {name: string; value: number; label: 'web-vitals' | 'custom'}) {
+    if (label === 'web-vitals') {
+        reportSpeed(name, name === 'CLS' ? value * 1000 : value);
+    }
 }
 
 


### PR DESCRIPTION
Google Analyticsのカスタム速度の記録はランダムに行なわれているので、リソースのほとんどがReactのカスタム速度に使われてしまっていた。
ので、web-vitalsだけを記録するようにした。

Closed #197
