### PR TITLE
VercelがGitHubにコメントしないように

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,7 @@
 {
+  "github": {
+    "silent": true
+  },
   "build": {
     "env": {
       "GITHUB_TOKEN": "@blanktar--github-token",


### PR DESCRIPTION
よく考えるとデプロイの結果はEnvironmentとかChecksとかで見れるので、コメントは無くても良い。
そんなことよりもメールがうるさい。
