### PR TITLE
JsonLDが原因でページを開いたときに出ていたエラーを修正

### DIFF
--- a/components/CommonResources.tsx
+++ b/components/CommonResources.tsx
@@ -65,7 +65,11 @@ const CommonResources: FC = () => {
 
             <link rel="alternate" type="application/atom+xml" href="/blog/feed.xml" key="feed" />
 
-            <JsonLD data={Website} key="jsonld--website" />
+            {/*
+                XXX: avoid recursive elements because Head can't have nested children inside.
+                seealso: https://github.com/macrat/blanktar/issues/485
+            */}
+            {JsonLD({ data: Website })}
         </Head>
     );
 };


### PR DESCRIPTION
Headタグの内部で要素を入れ子にすると、読み込まれた時に入れ子の中身を上手く認識出来ずにエラーになるっぽい。
なので、子コンポーネントではなく単純な関数呼び出し扱いにしてしまって解決した。
ちょっとキモチワルイ。

Close #485
