### PR TITLE
FireFoxだとworksのレイアウトが崩れていた問題を修正

### DIFF
--- a/pages/works.tsx
+++ b/pages/works.tsx
@@ -87,7 +87,8 @@ const GithubRepository: FC<Repository> = ({ name, images, url, createdAt, update
         <style jsx>{`
             li {
                 display: block;
-                width: calc(100% / 2 - 2mm * 2);
+                width: calc(100% / 2 - 2mm * 2 - 1px);
+                box-sizing: border-box;
                 height: 7cm;
                 margin: 2mm;
                 background-color: var(--colors-dark-fg);
@@ -215,6 +216,7 @@ const Works: NextPage<Props> = ({ repositories }) => (
                     padding: 0;
                     display: flex;
                     flex-wrap: wrap;
+                    justify-content: center;
                 }
                 div {
                     text-align: center;


### PR DESCRIPTION
折り返しの計算が若干違うらしく、縦に一列しか表示されていなかった。
