### PR TITLE
Lighthouseの設定を変更

### DIFF
--- a/.github/lighthouse.json
+++ b/.github/lighthouse.json
@@ -18,6 +18,7 @@
         "dom-size": "warn",
         "link-text": "warn",
         "non-composited-animations": "warn",
+        "unsized-images": "warn",
         "uses-http2": "off",
         "uses-responsive-images": "warn",
         "uses-webp-images": "warn"

--- a/.github/lighthouse.json
+++ b/.github/lighthouse.json
@@ -19,6 +19,7 @@
         "link-text": "warn",
         "non-composited-animations": "warn",
         "unsized-images": "warn",
+        "unused-javascript": "off",
         "uses-http2": "off",
         "uses-responsive-images": "warn",
         "uses-webp-images": "warn"


### PR DESCRIPTION
unsized-imagesはnext/imageの仕様なので諦める。悪影響は無いはず。

unused-javascriptについてもnext.jsの仕様。
独自で読み込んでいるファイル類は無いので、この検査は不要ということにする。
