### PR TITLE
Lighthouseのpreload-lcp-resourcesを無効化

### DIFF
--- a/.github/lighthouse.json
+++ b/.github/lighthouse.json
@@ -19,6 +19,7 @@
         "dom-size": "warn",
         "link-text": "warn",
         "non-composited-animations": "warn",
+        "preload-lcp-resources": "off",
         "unsized-images": "warn",
         "unused-javascript": "off",
         "uses-http2": "off",


### PR DESCRIPTION
#610 でworksとphotosに対してエラーが出ているが、LCPには影響していない。
next/imageのpriorityを使えないか試してみたけれど、挙動が怪しいので単純にルール無効化で対応。