### PR TITLE
Renovateのminor-updatesからnextを除外

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
       "updateTypes": ["minor", "patch"],
       "groupName": "minor updates",
       "excludePackagePatterns": [
-        "next"
+        "^next$"
       ]
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,10 @@
   "packageRules": [
     {
       "updateTypes": ["minor", "patch"],
-      "groupName": "minor updates"
+      "groupName": "minor updates",
+      "excludePackagePatterns": [
+        "next"
+      ]
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
Next.jsはマイナーアップデートでもビルドが通らなくなることが結構あるので、PRをまとめないようにする。
